### PR TITLE
Feature/local storage

### DIFF
--- a/src/feature/converter/ConverterContext.tsx
+++ b/src/feature/converter/ConverterContext.tsx
@@ -24,7 +24,7 @@ export const ConverterContext = createContext<ConverterContext | null>(null);
 const ConverterContextProvider = ({ children }: { children: ReactNode }) => {
   // Locale storage
   const { getItem, setItem } = useLocalStorage("userPresences");
-  const storedPrefs = getItem("userPresences");
+  const storedPrefs = getItem("userPresences") ?? {};
 
   // States
   const [input, setInput] = useState<number>(storedPrefs.input ?? 4000);

--- a/src/feature/converter/ConverterContext.tsx
+++ b/src/feature/converter/ConverterContext.tsx
@@ -39,16 +39,6 @@ const ConverterContextProvider = ({ children }: { children: ReactNode }) => {
   );
   const [updatedAt, setUpdatedAt] = useState<string>("");
 
-  // useEffect(() => {
-  //   const storedPrefs = getItem("userPresences");
-  //
-  //   if (storedPrefs) {
-  //     setInput(storedPrefs.input ?? 4000);
-  //     setFromCurrency(storedPrefs.fromCurrency ?? "USD");
-  //     setToCurrency(storedPrefs.toCurrency ?? "UZS");
-  //   }
-  // }, []);
-
   useEffect(() => {
     setItem({
       input,

--- a/src/feature/converter/ConverterContext.tsx
+++ b/src/feature/converter/ConverterContext.tsx
@@ -22,25 +22,32 @@ interface ConverterContext {
 export const ConverterContext = createContext<ConverterContext | null>(null);
 
 const ConverterContextProvider = ({ children }: { children: ReactNode }) => {
-  const [input, setInput] = useState<number>(4000);
-  const [fromCurrency, setFromCurrency] = useState<string>("USD");
-  const [toCurrency, setToCurrency] = useState<string>("UZS");
+  // Locale storage
+  const { getItem, setItem } = useLocalStorage("userPresences");
+  const storedPrefs = getItem("userPresences");
+
+  // States
+  const [input, setInput] = useState<number>(storedPrefs.input ?? 4000);
+  const [fromCurrency, setFromCurrency] = useState<string>(
+    storedPrefs.fromCurrency ?? "USD",
+  );
+  const [toCurrency, setToCurrency] = useState<string>(
+    storedPrefs.toCurrency ?? "UZS",
+  );
   const [currencyRates, setCurrencyRates] = useState<CurrencyRates | null>(
     null,
   );
   const [updatedAt, setUpdatedAt] = useState<string>("");
 
-  const { getItem, setItem } = useLocalStorage("userPresences");
-
-  useEffect(() => {
-    const storedPrefs = getItem("userPresences");
-
-    if (storedPrefs) {
-      setInput(storedPrefs.input ?? 4000);
-      setFromCurrency(storedPrefs.fromCurrency ?? "USD");
-      setToCurrency(storedPrefs.toCurrency ?? "UZS");
-    }
-  }, []);
+  // useEffect(() => {
+  //   const storedPrefs = getItem("userPresences");
+  //
+  //   if (storedPrefs) {
+  //     setInput(storedPrefs.input ?? 4000);
+  //     setFromCurrency(storedPrefs.fromCurrency ?? "USD");
+  //     setToCurrency(storedPrefs.toCurrency ?? "UZS");
+  //   }
+  // }, []);
 
   useEffect(() => {
     setItem({

--- a/src/feature/converter/ConverterContext.tsx
+++ b/src/feature/converter/ConverterContext.tsx
@@ -34,6 +34,7 @@ const ConverterContextProvider = ({ children }: { children: ReactNode }) => {
 
   useEffect(() => {
     const storedPrefs = getItem("userPresences");
+
     if (storedPrefs) {
       setInput(storedPrefs.input ?? 4000);
       setFromCurrency(storedPrefs.fromCurrency ?? "USD");

--- a/src/feature/converter/ConverterContext.tsx
+++ b/src/feature/converter/ConverterContext.tsx
@@ -1,4 +1,5 @@
-import { createContext, type ReactNode, useState } from "react";
+import { createContext, type ReactNode, useEffect, useState } from "react";
+import useLocalStorage from "../../hooks/useLocalStorage.ts";
 
 interface CurrencyRates {
   [currencyCode: string]: number;
@@ -28,6 +29,25 @@ const ConverterContextProvider = ({ children }: { children: ReactNode }) => {
     null,
   );
   const [updatedAt, setUpdatedAt] = useState<string>("");
+
+  const { getItem, setItem } = useLocalStorage("userPresences");
+
+  useEffect(() => {
+    const storedPrefs = getItem("userPresences");
+    if (storedPrefs) {
+      setInput(storedPrefs.input ?? 4000);
+      setFromCurrency(storedPrefs.fromCurrency ?? "USD");
+      setToCurrency(storedPrefs.toCurrency ?? "UZS");
+    }
+  }, []);
+
+  useEffect(() => {
+    setItem({
+      input,
+      fromCurrency,
+      toCurrency,
+    });
+  }, [input, fromCurrency, toCurrency, setItem]);
 
   const switchCurrency = () => {
     const tempCurrency = fromCurrency;

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -1,0 +1,17 @@
+const useLocalStorage = (key: string) => {
+  const setItem = (value: unknown) => {
+    window.localStorage.setItem(key, JSON.stringify(value));
+  };
+
+  const getItem = (key: string) => {
+    const item = window.localStorage.getItem(key);
+    return item ? JSON.parse(item) : undefined;
+  };
+
+  return {
+    setItem,
+    getItem,
+  };
+};
+
+export default useLocalStorage;

--- a/src/ui/input/Input.tsx
+++ b/src/ui/input/Input.tsx
@@ -2,10 +2,11 @@ import styles from "./Input.module.scss";
 
 interface InputProps {
   input: string;
+  defaultValue: number;
   setInput: (input: string) => void;
 }
 
-const Input = ({ input, setInput }: InputProps) => {
+const Input = ({ input, defaultValue, setInput }: InputProps) => {
   return (
     <div className={styles.inputContainer}>
       <label htmlFor="amount" className={styles.labelText}>
@@ -17,6 +18,7 @@ const Input = ({ input, setInput }: InputProps) => {
           type="text"
           id="amount"
           value={input}
+          defaultValue={defaultValue}
           min={0}
           onChange={(e) => setInput(e.target.value)}
         />

--- a/src/ui/input/Input.tsx
+++ b/src/ui/input/Input.tsx
@@ -2,13 +2,10 @@ import styles from "./Input.module.scss";
 
 interface InputProps {
   input: string;
-  defaultValue: number;
   setInput: (input: string) => void;
 }
 
-const Input = ({ input, defaultValue, setInput }: InputProps) => {
-  console.log(defaultValue);
-
+const Input = ({ input, setInput }: InputProps) => {
   return (
     <div className={styles.inputContainer}>
       <label htmlFor="amount" className={styles.labelText}>
@@ -20,7 +17,6 @@ const Input = ({ input, defaultValue, setInput }: InputProps) => {
           type="text"
           id="amount"
           value={input}
-          defaultValue={defaultValue}
           min={0}
           onChange={(e) => setInput(e.target.value)}
         />

--- a/src/ui/input/Input.tsx
+++ b/src/ui/input/Input.tsx
@@ -7,6 +7,8 @@ interface InputProps {
 }
 
 const Input = ({ input, defaultValue, setInput }: InputProps) => {
+  console.log(defaultValue);
+
   return (
     <div className={styles.inputContainer}>
       <label htmlFor="amount" className={styles.labelText}>

--- a/src/ui/input/instances/ConverterInput.tsx
+++ b/src/ui/input/instances/ConverterInput.tsx
@@ -37,7 +37,7 @@ const ConverterInput = () => {
 
   return (
     <div className={styles.container}>
-      <Input input={input} setInput={validate} defaultValue={contextInput} />
+      <Input input={input} setInput={validate} />
       <p className={styles.error}>{error}</p>
     </div>
   );

--- a/src/ui/input/instances/ConverterInput.tsx
+++ b/src/ui/input/instances/ConverterInput.tsx
@@ -1,4 +1,4 @@
-import { useContext, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import { ConverterContext } from "../../../feature/converter/ConverterContext.tsx";
 import Input from "../Input.tsx";
 import styles from "./ConvertInput.module.scss";
@@ -11,7 +11,11 @@ const ConverterInput = () => {
   if (!context)
     throw new Error("ConverterInput must be used inside the ConverterContext");
 
-  const { setInput: setContextInput } = context;
+  const { setInput: setContextInput, input: contextInput } = context;
+
+  useEffect(() => {
+    setInput(contextInput.toString());
+  }, [contextInput]);
 
   const validate = (value: string) => {
     setInput(value);
@@ -37,7 +41,7 @@ const ConverterInput = () => {
 
   return (
     <div className={styles.container}>
-      <Input input={input} setInput={validate} />
+      <Input input={input} setInput={validate} defaultValue={contextInput} />
       <p className={styles.error}>{error}</p>
     </div>
   );

--- a/src/ui/input/instances/ConverterInput.tsx
+++ b/src/ui/input/instances/ConverterInput.tsx
@@ -1,21 +1,17 @@
-import { useContext, useEffect, useState } from "react";
+import { useContext, useState } from "react";
 import { ConverterContext } from "../../../feature/converter/ConverterContext.tsx";
 import Input from "../Input.tsx";
 import styles from "./ConvertInput.module.scss";
 
 const ConverterInput = () => {
-  const [input, setInput] = useState<string>("");
-  const [error, setError] = useState("");
-
   const context = useContext(ConverterContext);
   if (!context)
     throw new Error("ConverterInput must be used inside the ConverterContext");
 
   const { setInput: setContextInput, input: contextInput } = context;
 
-  useEffect(() => {
-    setInput(contextInput.toString());
-  }, [contextInput]);
+  const [input, setInput] = useState<string>(() => contextInput.toString());
+  const [error, setError] = useState("");
 
   const validate = (value: string) => {
     setInput(value);


### PR DESCRIPTION
In this pull request:
- Created useLocalStorage hook
- Save user preferences to local storage on change: `input`, `fromCurrency` and `toCurrency`
- Load user preferences on initial load form local storage
- Prevent errors on empty local storage